### PR TITLE
Allocate on the heap instead of the stack to avoid segfaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 generated/*
+.idea/*

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,9 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+**/.idea/**

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ run: build/node_exporter_aix
 
 bff: clean build/node_exporter_aix
 	sed "s/VERSION/$(GIT_VERSION)/; s%PWD%$(PWD)%;" bff_template > build/bff_template
-	sudo rm -rf build/root
+	rm -rf build/root
 	mkdir -p build/root/usr/local/bin/
 	cp build/node_exporter_aix build/root/usr/local/bin/
-	sudo chown root.system build/root/usr/local/bin/node_exporter_aix
-	sudo mkinstallp -d build/root -T build/bff_template
+	chown root.system build/root/usr/local/bin/node_exporter_aix
+	mkinstallp -d build/root -T build/bff_template
 	cp build/root/tmp/node_exporter_aix.$(GIT_VERSION).bff build/
 
 clean:
-	sudo rm -rf build/* generated/*
+	rm -rf build/* generated/*

--- a/README.md
+++ b/README.md
@@ -75,6 +75,48 @@ To see all available configuration flags:
 
     ./build/node_exporter_aix -h
     
+## Building on IBM Cloud
+
+Create an AIX7.1 Machine
+Login and enter a bash shell
+    
+Instructions for 7.1
+Create space
+Allow more partitions
+
+`chvg -t 10 rootvg`
+
+Extend volumegroup
+
+`extendvg rootvg hdisk1`
+
+Add space to filesystem to opt folder where yum items are installed
+
+`chfs -a size=+5G /dev/hd10opt`
+`chfs -a size=+10G /dev/hd3`
+`chfs -a size=+10G /dev/hd9var`
+`chfs -a size=+5G /dev/hd2`
+`chfs -a size=+5G /dev/hd4`
+
+Start installing dev tools
+
+`curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/gcc/gcc-8-1.aix7.1.ppc.rpm`
+`rpm -i gcc-8-1.aix7.1.ppc.rpm`
+`export PATH=/opt/freeware/bin/:$PATH`
+`yum install gcc-cplusplus-8-1.aix7.1.ppc.rpm`
+`curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/git/git-core-2.35.1-1.aix7.1.ppc.rpm`
+`yum install git-core-2.35.1-1.aix7.1.ppc.rpm`
+`curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/curl/curl-7.83.1-1.aix7.1.ppc.rpm`
+`yum install curl-7.83.1-1.aix7.1.ppc.rpm`
+`curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/make/make-4.3-1.aix6.1.ppc.rpm`
+`yum install make-4.3-1.aix6.1.ppc.rpm`
+
+`smitty install_all`
+
+Enter input device by hitting f4 and select /usr/sys/inst.images then find package installp
+
+Finally go to the root directory and run `gmake`
+
 # Contributing
 Please see [CONTRIBUTING.md](CONTRIBUTING.md).  We welcome issues, pull requests and general suggestions.
 

--- a/README.md
+++ b/README.md
@@ -101,14 +101,23 @@ Add space to filesystem to opt folder where yum items are installed
 Start installing dev tools
 
 `curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/gcc/gcc-8-1.aix7.1.ppc.rpm`
+
 `rpm -i gcc-8-1.aix7.1.ppc.rpm`
+
 `export PATH=/opt/freeware/bin/:$PATH`
+
 `yum install gcc-cplusplus-8-1.aix7.1.ppc.rpm`
+
 `curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/git/git-core-2.35.1-1.aix7.1.ppc.rpm`
+
 `yum install git-core-2.35.1-1.aix7.1.ppc.rpm`
+
 `curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/curl/curl-7.83.1-1.aix7.1.ppc.rpm`
+
 `yum install curl-7.83.1-1.aix7.1.ppc.rpm`
+
 `curl -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/make/make-4.3-1.aix6.1.ppc.rpm`
+
 `yum install make-4.3-1.aix6.1.ppc.rpm`
 
 `smitty install_all`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ flag | Description
 -a | net adapter statistics
 -b | net buffer statistics
 -p | partition statistics
+-U | Busy Consumed CPU statistics
+-R | Process statistics
 
 ## Install package
     installp -ac -d <package_file.bff>

--- a/collectors.cpp
+++ b/collectors.cpp
@@ -62,7 +62,7 @@ void output_cpus_stat(std::ostream& response, const std::string& static_labels, 
 void gather_cpus_compat(std::ostream& response, const std::string& static_labels) {
 	int cpu_count = perfstat_cpu(NULL, NULL, sizeof(perfstat_cpu_t), 0);
 
-	perfstat_cpu_t cpus[cpu_count];
+    perfstat_cpu_t *cpus = new perfstat_cpu_t[cpu_count];
 	perfstat_id_t firstcpu;
 
 	strcpy(firstcpu.name, FIRST_CPU);
@@ -76,6 +76,8 @@ void gather_cpus_compat(std::ostream& response, const std::string& static_labels
 	output_cpus_stat_mode(response, static_labels, "node_cpu", "idle", "Seconds the cpus spent in each mode.", cpus, cpu_count, [](perfstat_cpu_t& cpu) { return (u_longlong_t)cpu.idle/100; });
 	output_cpus_stat_mode(response, static_labels, "node_cpu", "sys",  "Seconds the cpus spent in each mode.", cpus, cpu_count, [](perfstat_cpu_t& cpu) { return (u_longlong_t)cpu.sys/100;  });
 	output_cpus_stat_mode(response, static_labels, "node_cpu", "wait", "Seconds the cpus spent in each mode.", cpus, cpu_count, [](perfstat_cpu_t& cpu) { return (u_longlong_t)cpu.wait/100; });
+    delete [] cpus;
+
 }
 
 

--- a/data_sources/diskadapter.multiple
+++ b/data_sources/diskadapter.multiple
@@ -14,13 +14,3 @@ counter	 dk_rxfers	Number of  transfers from disk
 counter	 dk_rserv	read or receive service time
 counter	 dk_wserv	write or send service time
 counter	 min_rserv	Minimum read service time
-counter	 max_rserv	Maximum read service time
-counter	 min_wserv	Minimum Write service time
-counter	 max_wserv	Maximum write service time
-gauge	 wq_depth	driver wait queue depth
-counter	 wq_sampled	accumulated sampled dk_wq_depth
-counter	 wq_time	accumulated wait queueing time
-gauge	 wq_min_time	minimum wait queueing time
-gauge	 wq_max_time	maximum wait queueing time
-counter	 q_full		"Service" queue full occurrence count (number of times the adapter/devices connected to the adapter is not accepting any more request)
-counter	 q_sampled	accumulated sampled

--- a/data_sources/diskpath.multiple
+++ b/data_sources/diskpath.multiple
@@ -17,7 +17,6 @@ counter	wfailed		number of failed write requests
 counter	min_wserv	min write or send service time
 counter	max_wserv	max write or send service time
 counter	wq_depth	instantaneous wait queue depth (number of requests waiting to be sent to disk)
-counter	wq_sampled	accumulated sampled dk_wq_depth
 counter	wq_time		accumulated wait queueing time
 counter	wq_min_time	min wait queueing time
 counter	wq_max_time	max wait queueing time

--- a/scripts/generate_multiple.ksh
+++ b/scripts/generate_multiple.ksh
@@ -29,5 +29,5 @@ done
 tail -n +3  $input | sed "s/\"/'/g" | while read type name desc; do
 	echo "\toutput_${struct_name}_stat_mode(response, static_labels, \"aix_${struct_name}_${name}\", \"${type}\", \"${desc}\", ${struct_name}s, ${struct_name}_count, [](perfstat_${struct_name}_t& ${struct_name}) { return ${struct_name}.${name}; });" >> $output
 done
-
+echo "delete [] "$struct_name"s;" >> $output
 echo "}" >> $output

--- a/server.cpp
+++ b/server.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <thread>
 #include <sstream>
+#include <libperfstat.h>
 
 #include "server_http.hpp"
 
@@ -17,8 +18,10 @@ using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
 
 int start_server(int port, int flags) {
 
+    perfstat_reset();
 	HttpServer server;
 	server.config.port = port;
+    server.config.timeout_request = 30;
 
 	server.default_resource["GET"] = [flags](std::shared_ptr<HttpServer::Response> response, std::shared_ptr<HttpServer::Request> request) {
 		std::ostringstream output;

--- a/templates/generate_multiple.template
+++ b/templates/generate_multiple.template
@@ -18,6 +18,11 @@ void gather_STRUCT_NAMEs(std::ostream& response, const std::string& static_label
 
 	int STRUCT_NAME_count = perfstat_STRUCT_NAME(NULL, NULL, sizeof(perfstat_STRUCT_NAME_t), 0);
     std::cout << "STRUCT_NAME count is " << STRUCT_NAME_count << std::endl;
+    if (STRUCT_NAME_count == -1) {
+        std::cout << "STRUCT_NAME count returned error " << errno << std::endl;
+        perror("Error calling STRUCT_NAME");
+        return;
+    }
 	perfstat_STRUCT_NAME_t *STRUCT_NAMEs = new perfstat_STRUCT_NAME_t[STRUCT_NAME_count];
 	perfstat_ID_STRUCT_t firstSTRUCT_NAME;
 

--- a/templates/generate_multiple.template
+++ b/templates/generate_multiple.template
@@ -1,8 +1,13 @@
+#include <iostream>
+
 void output_STRUCT_NAME_stat_mode(std::ostream& response, const std::string& static_labels, const std::string& name, const std::string& type, const std::string& help, perfstat_STRUCT_NAME_t STRUCT_NAMEs[], size_t STRUCT_NAME_count, const std::function<double (perfstat_STRUCT_NAME_t&)>& func) {
 	response << "# HELP " << name << " " << help << std::endl;
 	response << "# TYPE " << name << " " << type << std::endl;
 
+    std::cout << "STRUCT_NAME getting name " <<  name  << std::endl;
+
 	for(size_t i=0; i<STRUCT_NAME_count; i++) {
+        std::cout << "STRUCT_NAME index " <<  i  << std::endl;
 		response << name << "{STRUCT_NAME=\"" << STRUCT_NAMEs[i].NAME_FIELD << "\",";
 		response << "LABEL=\"" << FORMAT_START STRUCT_NAMEs[i].LABEL FORMAT_END << "\",";
         response << static_labels << "} " << func(STRUCT_NAMEs[i]) << std::endl;
@@ -10,15 +15,21 @@ void output_STRUCT_NAME_stat_mode(std::ostream& response, const std::string& sta
 }
 
 void gather_STRUCT_NAMEs(std::ostream& response, const std::string& static_labels) {
-	int STRUCT_NAME_count = perfstat_STRUCT_NAME(NULL, NULL, sizeof(perfstat_STRUCT_NAME_t), 0);
 
+	int STRUCT_NAME_count = perfstat_STRUCT_NAME(NULL, NULL, sizeof(perfstat_STRUCT_NAME_t), 0);
+    std::cout << "STRUCT_NAME count is " << STRUCT_NAME_count << std::endl;
 	perfstat_STRUCT_NAME_t *STRUCT_NAMEs = new perfstat_STRUCT_NAME_t[STRUCT_NAME_count];
 	perfstat_ID_STRUCT_t firstSTRUCT_NAME;
 
+    std::cout << "STRUCT_NAME about to init "  << std::endl;
+
 	INITIALIZER;
+
+    std::cout << "STRUCT_NAME inited "  << std::endl;
 
 	if(perfstat_STRUCT_NAME(&firstSTRUCT_NAME, STRUCT_NAMEs, sizeof(perfstat_STRUCT_NAME_t), STRUCT_NAME_count) <= 0) {
 		perror("Error calling perfstat_STRUCT_NAME");
 		return;
 	}
+
 

--- a/templates/generate_multiple.template
+++ b/templates/generate_multiple.template
@@ -12,7 +12,7 @@ void output_STRUCT_NAME_stat_mode(std::ostream& response, const std::string& sta
 void gather_STRUCT_NAMEs(std::ostream& response, const std::string& static_labels) {
 	int STRUCT_NAME_count = perfstat_STRUCT_NAME(NULL, NULL, sizeof(perfstat_STRUCT_NAME_t), 0);
 
-	perfstat_STRUCT_NAME_t STRUCT_NAMEs[STRUCT_NAME_count];
+	perfstat_STRUCT_NAME_t *STRUCT_NAMEs = new perfstat_STRUCT_NAME_t[STRUCT_NAME_count];
 	perfstat_ID_STRUCT_t firstSTRUCT_NAME;
 
 	INITIALIZER;

--- a/templates/generate_multiple.template
+++ b/templates/generate_multiple.template
@@ -5,7 +5,7 @@ void output_STRUCT_NAME_stat_mode(std::ostream& response, const std::string& sta
 	for(size_t i=0; i<STRUCT_NAME_count; i++) {
 		response << name << "{STRUCT_NAME=\"" << STRUCT_NAMEs[i].NAME_FIELD << "\",";
 		response << "LABEL=\"" << FORMAT_START STRUCT_NAMEs[i].LABEL FORMAT_END << "\",";
-                response << static_labels << "} " << func(STRUCT_NAMEs[i]) << std::endl;
+        response << static_labels << "} " << func(STRUCT_NAMEs[i]) << std::endl;
 	}
 }
 


### PR DESCRIPTION
Caveat: I am not the best C++ programer.

Previously perf objects were allocated on the heap which by default is 96Kb on AIX. When dealing with a large number of perf instances this would case a segfault/invalid argument when calling the libperfstat function. Confused as to why it did not cause it on allocation, but moving to the heap solves the issue.

Added manual deletion of the objects, the memory could leak if an error occurred but that would involve a lot more SED work than I could easily do and in testing with customer environments we haven't seen any errors. 
